### PR TITLE
[Bugfix] String replaceAll should use newString to find next pos

### DIFF
--- a/src/shared/string.cpp
+++ b/src/shared/string.cpp
@@ -107,10 +107,10 @@ namespace kivm {
             auto newSize = newValue.size();
 
             String newString = string;
-            auto pos = newString.find(oldValue);
-            while (pos != std::string::npos) {
+            String::size_type pos = 0;
+            while ((pos = newString.find(oldValue, pos)) != String::npos) {
                 newString.replace(pos, oldSize, newValue);
-                pos = string.find(oldValue, pos + newSize);
+                pos += newSize;
             }
             return newString;
         }


### PR DESCRIPTION
```
        String replaceAll(const String &string, const String &oldValue, const String &newValue) {
            auto oldSize = oldValue.size();
            auto newSize = newValue.size();

            String newString = string;
            auto pos = newString.find(oldValue);
            while (pos != std::string::npos) {
                newString.replace(pos, oldSize, newValue);
                pos = string.find(oldValue, pos + newSize);
            }
            return newString;
        }
```

the find() in while loop should use newString

```
pos = newString.find(oldValue, pos + newSize);
````
